### PR TITLE
feat: allow decimals to be specified by strings or integers

### DIFF
--- a/adbc_drivers_validation/arrowjson.py
+++ b/adbc_drivers_validation/arrowjson.py
@@ -43,7 +43,9 @@ def array_from_values(values: list, field: pyarrow.Field) -> pyarrow.Array:
             base64.b64decode(value) if value is not None else None for value in values
         ]
     elif pyarrow.types.is_decimal(field.type):
-        return pyarrow.array(values, type=pyarrow.string()).cast(field.type)
+        return pyarrow.array(
+            [str(v) if v is not None else None for v in values], type=pyarrow.string()
+        ).cast(field.type)
     elif field.type.id == 37:
         # month_day_nano
         # format: 0M0d0ns

--- a/tests/test_arrowjson.py
+++ b/tests/test_arrowjson.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import decimal
 import io
 
 import pyarrow
@@ -181,6 +182,15 @@ def test_load_table_extra_fields():
             pyarrow.field("binary", pyarrow.binary(), nullable=True),
             pyarrow.array([b"hello", None], type=pyarrow.binary()),
             id="binary",
+        ),
+        pytest.param(
+            [123, "0.012345", None],
+            pyarrow.field("decimal", pyarrow.decimal128(38, 10), nullable=True),
+            pyarrow.array(
+                [decimal.Decimal("123"), decimal.Decimal("0.012345"), None],
+                type=pyarrow.decimal128(38, 10),
+            ),
+            id="decimal128(38, 10)",
         ),
     ],
 )


### PR DESCRIPTION
## What's Changed

Allow decimal values to be specified by integers (this makes it easier to override just the schema of a test case without having to change the values).
