### PR TITLE
fix: ignore nullability in compare_schemas

### DIFF
--- a/adbc_drivers_validation/compare.py
+++ b/adbc_drivers_validation/compare.py
@@ -59,7 +59,14 @@ def make_nullable(value: T) -> T:
                         )
                     )
                 else:
-                    fields.append(field)
+                    fields.append(
+                        pyarrow.field(
+                            field.name,
+                            field.type,
+                            nullable=True,
+                            metadata=field.metadata,
+                        )
+                    )
             return pyarrow.schema(fields)
         case pyarrow.Table():
             schema = make_nullable(value.schema)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -58,6 +58,13 @@ def test_compare_fields():
         compare.compare_fields(f1, f6)
 
 
+def test_compare_schemas_nullability():
+    # Should ignore nullability
+    s1 = pyarrow.schema([pyarrow.field("a", pyarrow.int32(), nullable=True)])
+    s2 = pyarrow.schema([pyarrow.field("a", pyarrow.int32(), nullable=False)])
+    compare.compare_schemas(s1, s2)
+
+
 @pytest.mark.parametrize(
     "value, expected",
     [


### PR DESCRIPTION
## What's Changed

Ignore nullability when comparing schema fields.
