### PR TITLE
feat: add `--repl` to pop a REPL with a connection

### DIFF
--- a/adbc_drivers_validation/tests/conftest.py
+++ b/adbc_drivers_validation/tests/conftest.py
@@ -30,6 +30,10 @@ pytest.register_assert_rewrite("adbc_drivers_validation.tests.query")
 pytest.register_assert_rewrite("adbc_drivers_validation.tests.statement")
 
 
+def pytest_addoption(parser):
+    parser.addoption("--repl", action="store_true", default=False)
+
+
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
 ) -> None:
@@ -62,6 +66,11 @@ def pytest_collection_modifyitems(
                             item.user_properties.append((f"tag:{tag_name}", value))
                     else:
                         item.user_properties.append((f"tag:{tag_name}", tag_value))
+
+    if config.getoption("--repl"):
+        items[:] = [item for item in items if item.name.startswith("test_repl[")]
+    else:
+        items[:] = [item for item in items if not item.name.startswith("test_repl[")]
 
 
 @pytest.fixture(scope="session")

--- a/adbc_drivers_validation/tests/connection.py
+++ b/adbc_drivers_validation/tests/connection.py
@@ -881,3 +881,12 @@ class TestConnection:
         # Ignore the first column which is normally used to sort the table
         schema = pyarrow.schema(list(schema)[1:])
         compare.compare_schemas(expected_schema, schema)
+
+    def test_repl(
+        self,
+        driver: model.DriverQuirks,
+        conn: adbc_driver_manager.dbapi.Connection,
+    ) -> None:
+        import code
+
+        code.interact(local={"conn": conn, "driver": driver})


### PR DESCRIPTION
## What's Changed

Run with `--repl` to get a shell.

Must import `pytest_addoption` from `adbc_drivers_validation.tests.conftest` in your `conftest.py`.

Fixes #48.
