### PR TITLE
fix: handle types with metadata that are not extensions

### DIFF
--- a/adbc_drivers_validation/generate_documentation.py
+++ b/adbc_drivers_validation/generate_documentation.py
@@ -223,7 +223,7 @@ class ValidationReport:
 
 def arrow_type_name(arrow_type, metadata=None, show_type_parameters=False):
     # Special handling (sometimes we want params, sometimes not)
-    if metadata and (ext := metadata[b"ARROW:extension:name"]):
+    if metadata and (ext := metadata.get(b"ARROW:extension:name")):
         return f"extension<{ext.decode('utf-8')}>"
     if show_type_parameters:
         return str(arrow_type)


### PR DESCRIPTION
## What's Changed

This was unnecessarily assuming the only metadata would be the extension name.