### PR TITLE
fix: handle bind tests with multiple parameters, extension types

### DIFF
--- a/adbc_drivers_validation/generate_documentation.py
+++ b/adbc_drivers_validation/generate_documentation.py
@@ -541,11 +541,11 @@ def generate_includes(
     )
     for test_case in type_tests:
         query_set = query_sets[test_case["vendor_version"]]
-        arrow_type_names = {
-            arrow_type_name(field.type)
-            for query_name in test_case["query_names"]
-            for field in query_set.queries[query_name].query.bind_schema()
-        }
+        arrow_type_names = set()
+        for query_name in test_case["query_names"]:
+            bind_schema = query_set.queries[query_name].query.bind_schema()
+            field = bind_schema[-1]
+            arrow_type_names.add(arrow_type_name(field.type, field.metadata))
         sql_type = html.escape(test_case["sql_type"])
         for arrow_type in arrow_type_names:
             arrow_type = html.escape(arrow_type)


### PR DESCRIPTION
## What's Changed

Also bind parameter types are 1 (Arrow type) to many (SQL types).