### PR TITLE
fix: update result schema for large/view/fixed size types in ingest

### DIFF
--- a/adbc_drivers_validation/queries/ingest/binary_view.schema.json
+++ b/adbc_drivers_validation/queries/ingest/binary_view.schema.json
@@ -1,0 +1,15 @@
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "z",
+            "flags": ["nullable"]
+        }
+    ]
+}

--- a/adbc_drivers_validation/queries/ingest/fixed_size_binary.schema.json
+++ b/adbc_drivers_validation/queries/ingest/fixed_size_binary.schema.json
@@ -1,0 +1,15 @@
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "z",
+            "flags": ["nullable"]
+        }
+    ]
+}

--- a/adbc_drivers_validation/queries/ingest/large_binary.schema.json
+++ b/adbc_drivers_validation/queries/ingest/large_binary.schema.json
@@ -1,0 +1,15 @@
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "z",
+            "flags": ["nullable"]
+        }
+    ]
+}

--- a/adbc_drivers_validation/queries/ingest/large_string.schema.json
+++ b/adbc_drivers_validation/queries/ingest/large_string.schema.json
@@ -1,0 +1,15 @@
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "u",
+            "flags": ["nullable"]
+        }
+    ]
+}

--- a/adbc_drivers_validation/queries/ingest/string_view.schema.json
+++ b/adbc_drivers_validation/queries/ingest/string_view.schema.json
@@ -1,0 +1,15 @@
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "u",
+            "flags": ["nullable"]
+        }
+    ]
+}


### PR DESCRIPTION
## What's Changed

The default assumption is that in/out types match but here it's better to assume that the result type is regular binary not the 'special' type
