### PR TITLE
feat: add flag to summarize query-based test cases

### DIFF
--- a/adbc_drivers_validation/tests/conftest.py
+++ b/adbc_drivers_validation/tests/conftest.py
@@ -32,6 +32,7 @@ pytest.register_assert_rewrite("adbc_drivers_validation.tests.statement")
 
 def pytest_addoption(parser):
     parser.addoption("--repl", action="store_true", default=False)
+    parser.addoption("--show-queries", action="store_true", default=False)
 
 
 def pytest_collection_modifyitems(
@@ -71,6 +72,15 @@ def pytest_collection_modifyitems(
         items[:] = [item for item in items if item.name.startswith("test_repl[")]
     else:
         items[:] = [item for item in items if not item.name.startswith("test_repl[")]
+
+    if config.getoption("--show-queries"):
+        items[:] = [
+            item for item in items if item.name.startswith("test_show_queries[")
+        ]
+    else:
+        items[:] = [
+            item for item in items if not item.name.startswith("test_show_queries[")
+        ]
 
 
 @pytest.fixture(scope="session")

--- a/adbc_drivers_validation/tests/connection.py
+++ b/adbc_drivers_validation/tests/connection.py
@@ -278,7 +278,12 @@ class TestConnection:
             table_name,
         )
         with conn.cursor() as cursor:
-            cursor.execute(driver.drop_table(table_name=table_name))
+            try:
+                cursor.execute(driver.drop_table(table_name=table_name))
+            except adbc_driver_manager.Error as e:
+                # Some databases have no way to do DROP IF EXISTS
+                if not driver.is_table_not_found(table_name=None, error=e):
+                    raise
 
         objects = conn.adbc_get_objects(depth="tables").read_all().to_pylist()
         tables = [
@@ -390,7 +395,12 @@ class TestConnection:
             table_name,
         )
         with conn.cursor() as cursor:
-            cursor.execute(driver.drop_table(table_name=table_name))
+            try:
+                cursor.execute(driver.drop_table(table_name=table_name))
+            except adbc_driver_manager.Error as e:
+                # Some databases have no way to do DROP IF EXISTS
+                if not driver.is_table_not_found(table_name=None, error=e):
+                    raise
 
         objects = conn.adbc_get_objects(depth="columns").read_all().to_pylist()
         columns = [
@@ -563,7 +573,12 @@ class TestConnection:
             schema=schema,
         )
         with conn.cursor() as cursor:
-            cursor.execute(driver.drop_table(table_name=table_name))
+            try:
+                cursor.execute(driver.drop_table(table_name=table_name))
+            except adbc_driver_manager.Error as e:
+                # Some databases have no way to do DROP IF EXISTS
+                if not driver.is_table_not_found(table_name=None, error=e):
+                    raise
             cursor.adbc_ingest(table_name, data)
 
         objects = (
@@ -636,7 +651,13 @@ class TestConnection:
         )
         with conn.cursor() as cursor:
             for table in table_names:
-                stmt = driver.drop_table(table_name=table)
+                try:
+                    stmt = driver.drop_table(table_name=table)
+                except adbc_driver_manager.Error as e:
+                    # Some databases have no way to do DROP IF EXISTS
+                    if not driver.is_table_not_found(table_name=None, error=e):
+                        raise
+
                 with scoped_trace(stmt):
                     cursor.execute(stmt)
 

--- a/adbc_drivers_validation/tests/query.py
+++ b/adbc_drivers_validation/tests/query.py
@@ -180,6 +180,39 @@ class TestQuery:
                 schema = pyarrow.schema(list(schema)[1:])
                 compare.compare_schemas(expected_schema, schema)
 
+    def test_show_queries(
+        self,
+        driver: model.DriverQuirks,
+        query: model.Query,
+    ) -> None:
+        """Print out basic query metadata for debugging/development."""
+        print(query.name.ljust(30), ":", end=" ")
+        if isinstance(query.query, model.IngestQuery):
+            schema = query.query.expected_schema()
+            field = schema[1]
+            print(
+                str(field.type).ljust(40),
+                "=>",
+                query.metadata()["tags"]["sql-type-name"],
+            )
+        elif isinstance(query.query, model.SelectQuery):
+            schema = query.query.expected_schema()
+            field = schema[0]
+            if query.query.bind_path is not None:
+                print(
+                    str(field.type).ljust(40),
+                    "=>",
+                    query.metadata()["tags"]["sql-type-name"],
+                )
+            else:
+                print(
+                    query.metadata()["tags"]["sql-type-name"].ljust(40),
+                    "=>",
+                    field.type,
+                )
+        else:
+            raise TypeError(type(query.query))
+
 
 def _setup_query(
     driver: model.DriverQuirks,


### PR DESCRIPTION
## What's Changed

- Fix a few more places to handle vendors that have no way of doing a `DROP TABLE IF EXISTS`. We need to instead catch and silence the error.
- Add a flag to summarize the type mappings, so you can more easily check that they're correct without actually running the tests.

See #98.
