### PR TITLE
chore: run dev workflow when PR is edited

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -15,7 +15,8 @@
 name: Dev
 
 on:
-  pull_request: {}
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
   push:
     branches:
       - main


### PR DESCRIPTION
## What's Changed

Updates the dev.yaml workflow to run when a PR is edited. Without this, if a PR fails the workflow on creation, it can't be fixed. By default, pull_request is only triggered on opened, reopened, or synchronized. This adds "edited".