### PR TITLE
fix: report skipped tests in ingest results

### DIFF
--- a/adbc_drivers_validation/generate_documentation.py
+++ b/adbc_drivers_validation/generate_documentation.py
@@ -589,7 +589,6 @@ def generate_includes(
           test_module LIKE '%TestIngest'
           AND test_name = 'test_create'
           AND (tags->>'sql-type-name') IS NOT NULL
-          AND test_result != 'skipped'
         ORDER BY vendor_version, query_name
         """)
         .arrow()


### PR DESCRIPTION
## What's Changed

Changes the query that populates our validation result templates so ingest tests that are skipped are included. This aligns with how tests for other things (select, bind) are reported. "skip" in the validation suite can mean "not supported".

Closes https://github.com/adbc-drivers/validation/issues/109