### PR TITLE
docs: ensure footnotes work in raw HTML types table

### DIFF
--- a/adbc_drivers_validation/templates/types.md
+++ b/adbc_drivers_validation/templates/types.md
@@ -46,9 +46,24 @@
 <tr>
   <td>{{ arrow_type }}</td>
 {%- if sql_type_bind == sql_type_ingest %}
-<td colspan="2" style="text-align: center;">{{ sql_type_bind }}</td>
+{# Note: The blank lines below make footnotes work #}
+{# See https://github.com/adbc-drivers/validation/issues/114 #}
+<td colspan="2" style="text-align: center;">
+
+{{ sql_type_bind }}
+
+</td>
 {% else %}
-<td style="text-align: center;">{{ sql_type_bind }}</td><td style="text-align: center;">{{ sql_type_ingest }}</td>
+<td style="text-align: center;">
+
+{{ sql_type_bind }}
+
+</td>
+<td style="text-align: center;">
+
+{{ sql_type_ingest }}
+
+</td>
 {% endif %}
 </tr>
 {%- endfor %}


### PR DESCRIPTION
## What's Changed

This is the necessary fix to make footnotes work correctly in our generated validation pages. Before this, footnotes didn't work when the footnote reference was inside a raw HTML table without special handling. The special handling is to add blank lines around the templates and ensure the cell content isn't indented any more than myst-parser tolerates. Apparently this is 0-3 spaces. Once you indent it to 4 spaces, footnotes break. Maybe a ReST thing?

For this change, we just don't indent and surround with blank lines.

Closes #114 
