### PR TITLE
fix: use proper timestamp units in test queries

### DIFF
--- a/adbc_drivers_validation/compare.py
+++ b/adbc_drivers_validation/compare.py
@@ -121,15 +121,14 @@ def scalar_to_py_smart(value: pyarrow.Scalar) -> typing.Any:
     elif isinstance(value, pyarrow.TimestampScalar):
         match value.type.unit:
             case "s":
-                nanos = value.value * 1_000_000_000
+                instant = whenever.Instant.from_timestamp(value.value)
             case "ms":
-                nanos = value.value * 1_000_000
+                instant = whenever.Instant.from_timestamp_millis(value.value)
             case "us":
-                nanos = value.value * 1000
+                instant = whenever.Instant.from_timestamp_nanos(value.value * 1000)
             case "ns":
-                nanos = value.value
+                instant = whenever.Instant.from_timestamp_nanos(value.value)
 
-        instant = whenever.Instant.from_timestamp_nanos(nanos)
         if value.type.tz is None or value.type.tz == "":
             # A bit sketch
             naive = whenever.PlainDateTime.parse_iso(instant.format_iso()[:-1])

--- a/adbc_drivers_validation/queries/type/bind/timestamp_ms.setup.sql
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_ms.setup.sql
@@ -1,4 +1,4 @@
 CREATE TABLE test_timestamp (
     idx INT,
-    res TIMESTAMP
+    res TIMESTAMP(3)
 );

--- a/adbc_drivers_validation/queries/type/bind/timestamp_ns.setup.sql
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_ns.setup.sql
@@ -1,4 +1,4 @@
 CREATE TABLE test_timestamp (
     idx INT,
-    res TIMESTAMP
+    res TIMESTAMP(9)
 );

--- a/adbc_drivers_validation/queries/type/bind/timestamp_s.setup.sql
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_s.setup.sql
@@ -1,4 +1,4 @@
 CREATE TABLE test_timestamp (
     idx INT,
-    res TIMESTAMP
+    res TIMESTAMP(0)
 );

--- a/adbc_drivers_validation/queries/type/bind/timestamp_us.setup.sql
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_us.setup.sql
@@ -1,4 +1,4 @@
 CREATE TABLE test_timestamp (
     idx INT,
-    res TIMESTAMP
+    res TIMESTAMP(6)
 );


### PR DESCRIPTION
## What's Changed

Also, don't unnecessarily round-trip through nanos in the comparison code