### PR TITLE
feat: add statement_rows_affected_ddl flag

### DIFF
--- a/adbc_drivers_validation/model.py
+++ b/adbc_drivers_validation/model.py
@@ -113,6 +113,7 @@ class DriverFeatures:
     statement_get_parameter_schema: bool = False
     statement_prepare: bool = True
     statement_rows_affected: bool = False
+    statement_rows_affected_ddl: bool = True
     _current_catalog: str | FromEnv | None = None
     _current_schema: str | FromEnv | None = None
     _secondary_schema: str | FromEnv | None = None

--- a/adbc_drivers_validation/tests/statement.py
+++ b/adbc_drivers_validation/tests/statement.py
@@ -165,7 +165,10 @@ class TestStatement:
             cursor.adbc_statement.set_sql_query(f"CREATE TABLE {table_name} (id INT)")
             rows_affected = cursor.adbc_statement.execute_update()
 
-            if driver.features.statement_rows_affected:
+            if (
+                driver.features.statement_rows_affected
+                and driver.features.statement_rows_affected_ddl
+            ):
                 assert rows_affected == 0
             else:
                 assert rows_affected == -1


### PR DESCRIPTION
## What's Changed

Add statement_rows_affected_ddl feature flag to control CREATE TABLE expected behavior. This allows drivers like PostgreSQL and Snowflake (which return -1 for DDL but exact counts for DML) to use the standard test without overrides by setting the `statement_rows_affected = True` and `statement_rows_affected_ddl = False.`  

Closes #140.
