### PR TITLE
feat: use sqlglot for split_statement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "jinja2>=3.1.6,<4",
   "pyarrow>=22.0.0,<23",
   "pytest>=9.0.0,<10",
+  "sqlglot>=28.5.0",
   "whenever>=0.9.3,<0.10",
 ]
 


### PR DESCRIPTION
## What's Changed

Use sqlglot to split statements based on the vendor. 

https://github.com/adbc-drivers/databricks/pull/107#discussion_r2658758391 
