### PR TITLE
fix: add timestamp precision to test cases

### DIFF
--- a/adbc_drivers_validation/queries/ingest/timestamp_ms.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamp_ms.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(3)"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamp_ns.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamp_ns.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(9)"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamp_s.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamp_s.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(0)"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamp_us.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamp_us.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(6)"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamptz_ms.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamptz_ms.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(3) WITH TIME ZONE"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamptz_ns.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamptz_ns.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(9) WITH TIME ZONE"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamptz_s.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamptz_s.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(0) WITH TIME ZONE"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/ingest/timestamptz_us.txtcase
+++ b/adbc_drivers_validation/queries/ingest/timestamptz_us.txtcase
@@ -15,7 +15,7 @@
 // part: metadata
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(6) WITH TIME ZONE"
 
 // part: input_schema
 

--- a/adbc_drivers_validation/queries/type/bind/timestamp_ms.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_ms.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamp"
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(3)"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamp_ns.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_ns.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamp"
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(9)"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamp_s.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_s.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamp"
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(0)"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamp_us.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamp_us.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamp"
 
 [tags]
-sql-type-name = "TIMESTAMP"
+sql-type-name = "TIMESTAMP(6)"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamptz_ms.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamptz_ms.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamptz"
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(3) WITH TIME ZONE"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamptz_ns.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamptz_ns.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamptz"
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(9) WITH TIME ZONE"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamptz_s.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamptz_s.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamptz"
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(0) WITH TIME ZONE"
 
 // part: setup_query
 

--- a/adbc_drivers_validation/queries/type/bind/timestamptz_us.txtcase
+++ b/adbc_drivers_validation/queries/type/bind/timestamptz_us.txtcase
@@ -18,7 +18,7 @@
 drop = "test_timestamptz"
 
 [tags]
-sql-type-name = "TIMESTAMP WITH TIME ZONE"
+sql-type-name = "TIMESTAMP(6) WITH TIME ZONE"
 
 // part: setup_query
 


### PR DESCRIPTION
## What's Changed

Add the precision so it's clearer what the driver does.
