### PR TITLE
fix: explicitly mark table cells of untested cases

### DIFF
--- a/adbc_drivers_validation/generate_documentation.py
+++ b/adbc_drivers_validation/generate_documentation.py
@@ -406,7 +406,7 @@ def render(
     bind_dict = dict(template_vars["type_bind"])
     ingest_dict = dict(template_vars["type_ingest"])
     template_vars["type_bind_ingest"] = [
-        (k, bind_dict.get(k), ingest_dict.get(k))
+        (k, bind_dict.get(k, "(not tested)"), ingest_dict.get(k, "(not tested)"))
         for k in set(bind_dict) | set(ingest_dict)
     ]
 


### PR DESCRIPTION
## What's Changed

Don't display `None` which is a bit unfriendly.
