### PR TITLE
fix: make class fixtures classmethods

### DIFF
--- a/adbc_drivers_validation/tests/connection.py
+++ b/adbc_drivers_validation/tests/connection.py
@@ -742,8 +742,9 @@ class TestConnection:
                     assert column[field] == "YES"
 
     @pytest.fixture(scope="class")
+    @classmethod
     def get_objects_table(
-        self,
+        cls,
         driver: model.DriverQuirks,
         conn: adbc_driver_manager.dbapi.Connection,
     ) -> typing.Generator[tuple[str | None, str | None, str], None, None]:
@@ -780,8 +781,9 @@ class TestConnection:
                 driver.try_drop_table(cursor, table_name=table_name)
 
     @pytest.fixture(scope="class")
+    @classmethod
     def get_objects_constraints(
-        self,
+        cls,
         driver: model.DriverQuirks,
         conn: adbc_driver_manager.dbapi.Connection,
     ) -> None:
@@ -811,8 +813,9 @@ class TestConnection:
                     cursor.execute(stmt)
 
     @pytest.fixture(scope="function")
+    @classmethod
     def get_statistics_table(
-        self,
+        cls,
         driver: model.DriverQuirks,
         conn: adbc_driver_manager.dbapi.Connection,
     ) -> typing.Generator[tuple[str | None, str | None, str], None, None]:

--- a/adbc_drivers_validation/tests/query.py
+++ b/adbc_drivers_validation/tests/query.py
@@ -95,8 +95,9 @@ class TestQuery:
     """Tests that involve running queries."""
 
     @pytest.fixture(scope="module")
+    @classmethod
     def query_setup(
-        self,
+        cls,
         request: pytest.FixtureRequest,
         driver: model.DriverQuirks,
         conn: adbc_driver_manager.dbapi.Connection,

--- a/adbc_drivers_validation/tests/statement.py
+++ b/adbc_drivers_validation/tests/statement.py
@@ -77,8 +77,9 @@ def generate_tests(
 
 class TestStatement:
     @pytest.fixture(scope="module")
+    @classmethod
     def sample_table(
-        self, driver: model.DriverQuirks, conn: adbc_driver_manager.dbapi.Connection
+        cls, driver: model.DriverQuirks, conn: adbc_driver_manager.dbapi.Connection
     ) -> str:
         table_name = "sample_table"
         quoted_name = driver.quote_identifier(table_name)


### PR DESCRIPTION
This is due to a warning about an apparent upcoming change in pytest 10.
