### PR TITLE
fix: allow overriding the `test_rows_affected` DDL

### DIFF
--- a/adbc_drivers_validation/tests/statement.py
+++ b/adbc_drivers_validation/tests/statement.py
@@ -196,7 +196,12 @@ class TestStatement:
                     raise
 
             quoted_name = driver.quote_identifier(table_name)
-            cursor.adbc_statement.set_sql_query(f"CREATE TABLE {quoted_name} (id INT)")
+            cursor.adbc_statement.set_sql_query(
+                driver.query_override(
+                    "TestStatement.test_rows_affected.create_table",
+                    f"CREATE TABLE {quoted_name} (id INT)",
+                )
+            )
             rows_affected = cursor.adbc_statement.execute_update()
 
             if (


### PR DESCRIPTION
The hardcoded `CREATE TABLE` statement cannot be executed by databases that require a primary key and native type names (Spanner). Route it through `DriverQuirks.query_override`, matching the existing `sample_table` pattern; drivers without an override see no behavior change.