### PR TITLE
feat: let quirks declare a synthetic bulk-ingest column

### DIFF
--- a/adbc_drivers_validation/model.py
+++ b/adbc_drivers_validation/model.py
@@ -137,6 +137,9 @@ class DriverFeatures(BaseModel):
     _secondary_catalog: str | FromEnv | None = PrivateAttr(default=None)
     _secondary_catalog_schema: str | FromEnv | None = PrivateAttr(default=None)
     supported_xdbc_fields: list[str] = Field(default_factory=list)
+    # Some databases requires a primary key, so bulk ingestion needs to
+    # add a synthetic column for that.
+    bulk_ingest_synthetic_column: str | None = Field(default=None)
     # Some databases support temporary tables, but they exist in the same
     # namespace as regular tables, so we need to change how we test them.
     quirk_bulk_ingest_temporary_shares_namespace: bool = Field(default=False)

--- a/adbc_drivers_validation/tests/connection.py
+++ b/adbc_drivers_validation/tests/connection.py
@@ -585,6 +585,8 @@ class TestConnection:
         assert list(sorted(set(columns))) == list(sorted(columns))
         assert (*table_id, "ints") in columns
         assert (*table_id, "strs") in columns
+        synthetic = driver.features.bulk_ingest_synthetic_column
+        columns = [c for c in columns if c[-1] != synthetic]
         assert len(columns) == 2
 
     def test_get_objects_column_filter_catalog(
@@ -679,6 +681,8 @@ class TestConnection:
             for column in table["table_columns"]
         ]
         assert list(sorted(set(columns))) == list(sorted(columns))
+        synthetic = driver.features.bulk_ingest_synthetic_column
+        columns = [c for c in columns if c[-1] != synthetic]
         assert columns == [(*table_id, "ints"), (*table_id, "strs")]
 
     def test_get_objects_column_xdbc(


### PR DESCRIPTION
Some databases (Spanner) cannot create a table without a primary key, so their ADBC drivers needs to add a synthetic column during create-mode bulk ingest, which `get_objects` then reports. Two tests assert the column list of the ingested table exactly equals the ingested columns and therefore fail for such drivers.

Add a `bulk_ingest_synthetic_column` property to `DriverFeatures` (default `None`) and filter that column out before the two strict equality assertions. Membership-based assertions are untouched, and behavior for existing drivers is unchanged.

After this change (and the already merged #249) it seems no more changes to this validation suite is necessary for a Spanner ADBC driver (see [this reply](https://github.com/adbc-drivers/validation/pull/249#issuecomment-4914253735) about the status of that).
