### PR TITLE
feat: add ingest AlreadyExists tests

### DIFF
--- a/adbc_drivers_validation/tests/ingest.py
+++ b/adbc_drivers_validation/tests/ingest.py
@@ -283,6 +283,58 @@ class TestIngest:
             query.metadata(),
         )
 
+    def test_create_conflict(
+        self,
+        driver: model.DriverQuirks,
+        conn: adbc_driver_manager.dbapi.Connection,
+        query: Query,
+    ) -> None:
+        subquery = query.query
+        assert isinstance(subquery, model.IngestQuery)
+
+        table_name = make_table_name("test_ingest_create_conflict", query)
+        data = subquery.input()
+
+        with conn.cursor() as cursor:
+            driver.try_drop_table(cursor, table_name=table_name)
+            with driver.setup_statement(query, cursor):
+                cursor.adbc_ingest(table_name, data, mode="create")
+
+                with pytest.raises(adbc_driver_manager.dbapi.Error) as excinfo:
+                    cursor.adbc_ingest(table_name, data, mode="create")
+
+        assert (
+            excinfo.value.status_code
+            == adbc_driver_manager.AdbcStatusCode.ALREADY_EXISTS
+        )
+
+    def test_createappend_schema_mismatch(
+        self,
+        driver: model.DriverQuirks,
+        conn: adbc_driver_manager.dbapi.Connection,
+        query: Query,
+    ) -> None:
+        subquery = query.query
+        assert isinstance(subquery, model.IngestQuery)
+
+        table_name = make_table_name("test_ingest_createappend_mismatch", query)
+        data = subquery.input()
+        extra = pyarrow.array([0] * len(data), type=pyarrow.int64())
+        mismatched = data.append_column("adbc_extra_column", extra)
+
+        with conn.cursor() as cursor:
+            driver.try_drop_table(cursor, table_name=table_name)
+            with driver.setup_statement(query, cursor):
+                cursor.adbc_ingest(table_name, data, mode="create_append")
+
+                with pytest.raises(adbc_driver_manager.dbapi.Error) as excinfo:
+                    cursor.adbc_ingest(table_name, mismatched, mode="create_append")
+
+        assert (
+            excinfo.value.status_code
+            == adbc_driver_manager.AdbcStatusCode.ALREADY_EXISTS
+        )
+
     def test_replace(
         self,
         driver: model.DriverQuirks,


### PR DESCRIPTION
Add tests for the two ingestion mode contracts that require `ADBC_STATUS_ALREADY_EXISTS`:

- `CREATE` — error if the target table already exists. [adbc.h L806–807](https://github.com/apache/arrow-adbc/blob/c7c3b03954127ac1bacf091d141b8099eedfda83/c/include/arrow-adbc/adbc.h#L806-L807):

  > ```c
  > /// \brief Create the table and insert data; error if the table exists.
  > #define ADBC_INGEST_OPTION_MODE_CREATE "adbc.ingest.mode.create"
  > ```

- `CREATE_APPEND` — error if the table exists but its schema does not match the appended data. [adbc.h L819–823](https://github.com/apache/arrow-adbc/blob/c7c3b03954127ac1bacf091d141b8099eedfda83/c/include/arrow-adbc/adbc.h#L819-L823):

  > ```c
  > /// \brief Insert data; create the table if it does not exist, or
  > ///   error if the table exists, but the schema does not match the
  > ///   schema of the data to append (ADBC_STATUS_ALREADY_EXISTS).
  > /// \since ADBC API revision 1.1.0
  > #define ADBC_INGEST_OPTION_MODE_CREATE_APPEND "adbc.ingest.mode.create_append"
  > ```