### PR TITLE
feat: add configurable DML row counts and skip disabled test_get_objects_ instead of strict xfails

### DIFF
--- a/adbc_drivers_validation/model.py
+++ b/adbc_drivers_validation/model.py
@@ -134,7 +134,7 @@ class DriverFeatures(BaseModel):
     statement_prepare: bool = Field(default=False)
     statement_rows_affected: bool = Field(default=False)
     # Some backends report zero for every ordinary DML statement (ex: Databend)
-    statement_rows_affected_dml_returns_zero: bool = Field(default=False)
+    quirk_statement_rows_affected_dml_returns_zero: bool = Field(default=False)
     statement_rows_affected_ddl: bool = Field(default=False)
     _current_catalog: str | FromEnv | None = PrivateAttr(default=None)
     _current_schema: str | FromEnv | None = PrivateAttr(default=None)

--- a/adbc_drivers_validation/model.py
+++ b/adbc_drivers_validation/model.py
@@ -133,6 +133,8 @@ class DriverFeatures(BaseModel):
     statement_get_parameter_schema: bool = Field(default=False)
     statement_prepare: bool = Field(default=False)
     statement_rows_affected: bool = Field(default=False)
+    # Some backends report zero for every ordinary DML statement (ex: Databend)
+    statement_rows_affected_dml_returns_zero: bool = Field(default=False)
     statement_rows_affected_ddl: bool = Field(default=False)
     _current_catalog: str | FromEnv | None = PrivateAttr(default=None)
     _current_schema: str | FromEnv | None = PrivateAttr(default=None)

--- a/adbc_drivers_validation/model.py
+++ b/adbc_drivers_validation/model.py
@@ -133,8 +133,6 @@ class DriverFeatures(BaseModel):
     statement_get_parameter_schema: bool = Field(default=False)
     statement_prepare: bool = Field(default=False)
     statement_rows_affected: bool = Field(default=False)
-    # Some backends report zero for every ordinary DML statement (ex: Databend)
-    quirk_statement_rows_affected_dml_returns_zero: bool = Field(default=False)
     statement_rows_affected_ddl: bool = Field(default=False)
     _current_catalog: str | FromEnv | None = PrivateAttr(default=None)
     _current_schema: str | FromEnv | None = PrivateAttr(default=None)
@@ -153,6 +151,8 @@ class DriverFeatures(BaseModel):
     quirk_get_objects_constraints_foreign_normalized: bool = Field(default=False)
     quirk_get_objects_constraints_primary_normalized: bool = Field(default=False)
     quirk_get_objects_constraints_unique_normalized: bool = Field(default=False)
+    # Some backends report zero for every ordinary DML statement (ex: Databend)
+    quirk_statement_rows_affected_dml_returns_zero: bool = Field(default=False)
 
     def __init__(self, **data: typing.Any) -> None:
         super().__init__(**data)

--- a/adbc_drivers_validation/tests/connection.py
+++ b/adbc_drivers_validation/tests/connection.py
@@ -103,7 +103,7 @@ def generate_tests(
         elif not f.get_objects and metafunc.definition.name.startswith(
             "test_get_objects_"
         ):
-            marks.append(pytest.mark.xfail(reason="not implemented"))
+            marks.append(pytest.mark.skip(reason="not implemented"))
 
         combinations.append(pytest.param(driver_param, id=driver_param, marks=marks))
     metafunc.parametrize(

--- a/adbc_drivers_validation/tests/statement.py
+++ b/adbc_drivers_validation/tests/statement.py
@@ -59,11 +59,7 @@ def generate_tests(
             metafunc.definition.name == "test_prepare"
             and not quirks.features.statement_prepare
         ):
-            marks.append(
-                pytest.mark.xfail(
-                    raises=adbc_driver_manager.dbapi.NotSupportedError, strict=True
-                )
-            )
+            marks.append(pytest.mark.skip("prepare not supported"))
 
         combinations.append(pytest.param(driver_param, id=driver_param, marks=marks))
 
@@ -249,7 +245,10 @@ class TestStatement:
             )
             rows_affected = cursor.adbc_statement.execute_update()
             if driver.features.statement_rows_affected:
-                assert rows_affected == 1
+                if driver.features.statement_rows_affected_dml_returns_zero:
+                    assert rows_affected == 0
+                else:
+                    assert rows_affected == 1
             else:
                 assert rows_affected == -1
 
@@ -258,7 +257,10 @@ class TestStatement:
             )
             rows_affected = cursor.adbc_statement.execute_update()
             if driver.features.statement_rows_affected:
-                assert rows_affected == 1
+                if driver.features.statement_rows_affected_dml_returns_zero:
+                    assert rows_affected == 0
+                else:
+                    assert rows_affected == 1
             else:
                 assert rows_affected == -1
 
@@ -267,7 +269,10 @@ class TestStatement:
             )
             rows_affected = cursor.adbc_statement.execute_update()
             if driver.features.statement_rows_affected:
-                assert rows_affected == 1
+                if driver.features.statement_rows_affected_dml_returns_zero:
+                    assert rows_affected == 0
+                else:
+                    assert rows_affected == 1
             else:
                 assert rows_affected == -1
 

--- a/adbc_drivers_validation/tests/statement.py
+++ b/adbc_drivers_validation/tests/statement.py
@@ -59,7 +59,11 @@ def generate_tests(
             metafunc.definition.name == "test_prepare"
             and not quirks.features.statement_prepare
         ):
-            marks.append(pytest.mark.skip("prepare not supported"))
+            marks.append(
+                pytest.mark.xfail(
+                    raises=adbc_driver_manager.dbapi.NotSupportedError, strict=True
+                )
+            )
 
         combinations.append(pytest.param(driver_param, id=driver_param, marks=marks))
 

--- a/adbc_drivers_validation/tests/statement.py
+++ b/adbc_drivers_validation/tests/statement.py
@@ -249,7 +249,7 @@ class TestStatement:
             )
             rows_affected = cursor.adbc_statement.execute_update()
             if driver.features.statement_rows_affected:
-                if driver.features.statement_rows_affected_dml_returns_zero:
+                if driver.features.quirk_statement_rows_affected_dml_returns_zero:
                     assert rows_affected == 0
                 else:
                     assert rows_affected == 1
@@ -261,7 +261,7 @@ class TestStatement:
             )
             rows_affected = cursor.adbc_statement.execute_update()
             if driver.features.statement_rows_affected:
-                if driver.features.statement_rows_affected_dml_returns_zero:
+                if driver.features.quirk_statement_rows_affected_dml_returns_zero:
                     assert rows_affected == 0
                 else:
                     assert rows_affected == 1
@@ -273,7 +273,7 @@ class TestStatement:
             )
             rows_affected = cursor.adbc_statement.execute_update()
             if driver.features.statement_rows_affected:
-                if driver.features.statement_rows_affected_dml_returns_zero:
+                if driver.features.quirk_statement_rows_affected_dml_returns_zero:
                     assert rows_affected == 0
                 else:
                     assert rows_affected == 1


### PR DESCRIPTION
Some backends, such as Databend, report 0 rows affected for DML statements. Add a driver feature flag so the validation suite can expect this behavior.

Skipped `test_get_objects_ ` instead of marking strict xfail when disabled. In the MySQL driver, unfiltered GetObjects uses a plain query and may succeed on Databend, while filtered GetObjects uses bound parameters and falls back to prepared statements, which Databend does not support. With strict xfail, unfiltered cases can pass and turn into misleading XPASS failures even though get_objects is disabled for that backend. Skipping is clearer.

